### PR TITLE
Codebase quality improvements: bug fixes, perf, and simplification

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,7 +19,7 @@ preserve_dotfiles_in_output = false
 compile_sass = true
 
 # When set to "true", the generated HTML files are minified.
-minify_html = false
+minify_html = true
 
 # A list of glob patterns specifying asset files to ignore when the content
 # directory is processed. Defaults to none, which means that all asset files are
@@ -112,7 +112,7 @@ smart_punctuation = false
 # Whether to set decoding="async" and loading="lazy" for all images
 # When turned on, the alt text must be plain text.
 # For example, `![xx](...)` is ok but `![*x*x](...)` isn’t ok
-lazy_async_image = false
+lazy_async_image = true
 
 ###################################################################################################################
 ###################################################################################################################

--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -3,8 +3,6 @@ settings_locale = "ar"
 settings_date_locale = "ar_EG"
 settings_date_format = "%B %d, %Y"
 settings_direction = "rtl"
-settings_font_family = "scheherazade-new"
-settings_body_style = "rtl-grid"
 
 # The main navigation menu
 menu_pages = [

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -3,8 +3,6 @@ settings_locale = "en"
 settings_date_locale = "en_US"
 settings_date_format = "%B %d, %Y"
 settings_direction = "ltr"
-settings_font_family = ""
-settings_body_style = ""
 
 # The main navigation menu
 menu_pages = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "mos3abof.github.io",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.10",
         "tailwindcss": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "watch": "^0.13.0"
   },
   "scripts": {
-    "build": "NODE_ENV=production npx tailwindcss -i styles/input.css -o static/css/styles.css",
+    "build": "NODE_ENV=production npx tailwindcss -i styles/input.css -o static/css/style.css",
     "serve": "zola serve",
     "tailwind": "npx tailwindcss -i styles/input.css -o static/css/style.css --watch"
   },

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -661,7 +661,6 @@ article p {
   text-align: left;
   font-size: 1.25rem;
   line-height: 1.75rem;
-  font-weight: 500;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -801,8 +800,24 @@ pre {
   position: absolute;
 }
 
+.relative {
+  position: relative;
+}
+
+.left-3 {
+  left: 0.75rem;
+}
+
+.right-3 {
+  right: 0.75rem;
+}
+
 .top-0 {
   top: 0px;
+}
+
+.top-2 {
+  top: 0.5rem;
 }
 
 .z-10 {
@@ -853,6 +868,11 @@ pre {
   margin-bottom: 1.25rem;
 }
 
+.my-8 {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
 .my-auto {
   margin-top: auto;
   margin-bottom: auto;
@@ -878,8 +898,20 @@ pre {
   margin-top: 2.5rem;
 }
 
+.mt-2 {
+  margin-top: 0.5rem;
+}
+
 .mt-20 {
   margin-top: 5rem;
+}
+
+.mt-3 {
+  margin-top: 0.75rem;
+}
+
+.mt-4 {
+  margin-top: 1rem;
 }
 
 .mt-5 {
@@ -900,14 +932,6 @@ pre {
 
 .flex {
   display: flex;
-}
-
-.table {
-  display: table;
-}
-
-.contents {
-  display: contents;
 }
 
 .list-item {
@@ -934,6 +958,10 @@ pre {
   width: 100vw;
 }
 
+.max-w-2xl {
+  max-width: 42rem;
+}
+
 .max-w-6xl {
   max-width: 72rem;
 }
@@ -950,8 +978,32 @@ pre {
   transform-origin: top;
 }
 
+@keyframes open-menu {
+  0% {
+    transform: scaleY(0);
+  }
+
+  80% {
+    transform: scaleY(1.2);
+  }
+
+  100% {
+    transform: scaleY(1);
+  }
+}
+
+.animate-open-menu {
+  animation: open-menu 0.5s ease-in-out forwards;
+}
+
 .cursor-pointer {
   cursor: pointer;
+}
+
+.select-none {
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
 }
 
 .scroll-mt-40 {
@@ -1012,8 +1064,16 @@ pre {
   align-self: flex-end;
 }
 
+.rounded-lg {
+  border-radius: 0.5rem;
+}
+
 .rounded-xl {
   border-radius: 0.75rem;
+}
+
+.border {
+  border-width: 1px;
 }
 
 .border-s-4 {
@@ -1027,6 +1087,15 @@ pre {
 .border-gray-300 {
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity, 1));
+}
+
+.border-teal-600 {
+  --tw-border-opacity: 1;
+  border-color: rgb(13 148 136 / var(--tw-border-opacity, 1));
+}
+
+.border-teal-600\/40 {
+  border-color: rgb(13 148 136 / 0.4);
 }
 
 .bg-green-100 {
@@ -1044,6 +1113,11 @@ pre {
   background-color: rgb(252 231 243 / var(--tw-bg-opacity, 1));
 }
 
+.bg-slate-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(241 245 249 / var(--tw-bg-opacity, 1));
+}
+
 .bg-slate-200 {
   --tw-bg-opacity: 1;
   background-color: rgb(226 232 240 / var(--tw-bg-opacity, 1));
@@ -1057,6 +1131,10 @@ pre {
 .bg-teal-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(204 251 241 / var(--tw-bg-opacity, 1));
+}
+
+.bg-teal-50\/30 {
+  background-color: rgb(240 253 250 / 0.3);
 }
 
 .bg-yellow-100 {
@@ -1115,6 +1193,11 @@ pre {
   padding-right: 1.5rem;
 }
 
+.px-8 {
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
 .py-2 {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
@@ -1170,6 +1253,10 @@ pre {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
+.font-serif {
+  font-family: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+}
+
 .text-2xl {
   font-size: 1.5rem;
   line-height: 2rem;
@@ -1187,6 +1274,11 @@ pre {
 
 .text-7xl {
   font-size: 4.5rem;
+  line-height: 1;
+}
+
+.text-8xl {
+  font-size: 6rem;
   line-height: 1;
 }
 
@@ -1220,12 +1312,20 @@ pre {
   font-style: italic;
 }
 
+.not-italic {
+  font-style: normal;
+}
+
 .leading-\[0px\] {
   line-height: 0px;
 }
 
 .leading-loose {
   line-height: 2;
+}
+
+.leading-none {
+  line-height: 1;
 }
 
 .leading-normal {
@@ -1282,6 +1382,11 @@ pre {
   color: rgb(51 65 85 / var(--tw-text-opacity, 1));
 }
 
+.text-slate-800 {
+  --tw-text-opacity: 1;
+  color: rgb(30 41 59 / var(--tw-text-opacity, 1));
+}
+
 .text-slate-900 {
   --tw-text-opacity: 1;
   color: rgb(15 23 42 / var(--tw-text-opacity, 1));
@@ -1290,6 +1395,15 @@ pre {
 .text-teal-600 {
   --tw-text-opacity: 1;
   color: rgb(13 148 136 / var(--tw-text-opacity, 1));
+}
+
+.text-teal-600\/20 {
+  color: rgb(13 148 136 / 0.2);
+}
+
+.text-teal-700 {
+  --tw-text-opacity: 1;
+  color: rgb(15 118 110 / var(--tw-text-opacity, 1));
 }
 
 .text-teal-800 {
@@ -1313,6 +1427,12 @@ pre {
 
 .underline-offset-4 {
   text-underline-offset: 4px;
+}
+
+.shadow-sm {
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .shadow-xl {
@@ -1417,6 +1537,7 @@ pre {
 
 .rtl-grid {
   direction: rtl;
+  font-family: "Amiri", serif;
 }
 
 .rtl-grid p {
@@ -1430,6 +1551,48 @@ pre {
 .noto-sans {
   font-family: "Noto Sans Arabic", sans-serif;
   font-optical-sizing: auto;
+}
+
+/* ── Arabic font classes ───────────────────────── */
+
+.amiri             {
+  font-family: "Amiri", serif;
+}
+
+.amiri-quran       {
+  font-family: "Amiri Quran", serif;
+}
+
+.kufam             {
+  font-family: "Kufam", sans-serif;
+}
+
+/* ── Arabic typography system ─────────────────── */
+
+/* Kufam for all headings in RTL (Arabic) pages */
+
+.rtl-grid article h1,
+.rtl-grid article h2,
+.rtl-grid article h3,
+.rtl-grid article h4 {
+  font-family: "Kufam", sans-serif;
+  font-weight: 700;
+}
+
+/* Amiri for Arabic article body text */
+
+.rtl-grid article p {
+  font-family: "Amiri", serif;
+  font-size: 1.4rem;
+  font-weight: 400;
+  line-height: 2.2;
+  text-align: right;
+}
+
+.rtl-grid article strong,
+.rtl-grid strong {
+  font-family: "Amiri", serif;
+  font-weight: 700;
 }
 
 .selection\:bg-blue-600 *::-moz-selection {
@@ -1696,6 +1859,15 @@ pre {
     background-color: rgb(30 41 59 / var(--tw-bg-opacity, 1));
   }
 
+  .dark\:bg-slate-900 {
+    --tw-bg-opacity: 1;
+    background-color: rgb(15 23 42 / var(--tw-bg-opacity, 1));
+  }
+
+  .dark\:bg-teal-950\/20 {
+    background-color: rgb(4 47 46 / 0.2);
+  }
+
   .dark\:text-cyan-300 {
     --tw-text-opacity: 1;
     color: rgb(103 232 249 / var(--tw-text-opacity, 1));
@@ -1711,6 +1883,11 @@ pre {
     color: rgb(249 168 212 / var(--tw-text-opacity, 1));
   }
 
+  .dark\:text-slate-100 {
+    --tw-text-opacity: 1;
+    color: rgb(241 245 249 / var(--tw-text-opacity, 1));
+  }
+
   .dark\:text-slate-200 {
     --tw-text-opacity: 1;
     color: rgb(226 232 240 / var(--tw-text-opacity, 1));
@@ -1721,6 +1898,11 @@ pre {
     color: rgb(203 213 225 / var(--tw-text-opacity, 1));
   }
 
+  .dark\:text-slate-400 {
+    --tw-text-opacity: 1;
+    color: rgb(148 163 184 / var(--tw-text-opacity, 1));
+  }
+
   .dark\:text-slate-600 {
     --tw-text-opacity: 1;
     color: rgb(71 85 105 / var(--tw-text-opacity, 1));
@@ -1729,6 +1911,11 @@ pre {
   .dark\:text-teal-300 {
     --tw-text-opacity: 1;
     color: rgb(94 234 212 / var(--tw-text-opacity, 1));
+  }
+
+  .dark\:text-teal-400 {
+    --tw-text-opacity: 1;
+    color: rgb(45 212 191 / var(--tw-text-opacity, 1));
   }
 
   .dark\:text-violet-300 {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,15 +1,26 @@
 const initApp = () => {
   const hamburgerBtn = document.getElementById('hamburger-button')
   const mobileMenu = document.getElementById('mobile-menu')
+  const themeToggleBtn = document.getElementById('theme-toggle')
 
   const toggleMenu = () => {
-    mobileMenu.classList.toggle('hidden')
-    mobileMenu.classList.toggle('flex')
+    const isOpen = mobileMenu.classList.toggle('hidden') === false
+    mobileMenu.classList.toggle('flex', isOpen)
+    hamburgerBtn.setAttribute('aria-expanded', String(isOpen))
   }
-
 
   hamburgerBtn.addEventListener('click', toggleMenu)
   mobileMenu.addEventListener('click', toggleMenu)
+
+  themeToggleBtn.addEventListener('click', () => {
+    if (document.documentElement.classList.contains('dark')) {
+      document.documentElement.classList.remove('dark')
+      localStorage.setItem('color-theme', 'light')
+    } else {
+      document.documentElement.classList.add('dark')
+      localStorage.setItem('color-theme', 'dark')
+    }
+  })
 }
 
 document.addEventListener('DOMContentLoaded', initApp)

--- a/styles/input.css
+++ b/styles/input.css
@@ -95,8 +95,7 @@
   }
 
   article p {
-    @apply text-xl text-left dark:text-slate-200 pt-5 font-medium;
-
+    @apply text-xl text-left dark:text-slate-200 pt-5;
   }
 
   article a {
@@ -139,6 +138,7 @@
 
 .rtl-grid {
   direction: rtl;
+  font-family: "Amiri", serif;
 }
 
 .rtl-grid p {
@@ -155,17 +155,9 @@
 }
 
 /* ── Arabic font classes ───────────────────────── */
-.scheherazade-new  { font-family: "Scheherazade New", serif; }
-.kufam             { font-family: "Kufam", sans-serif; }
-.cairo             { font-family: "Cairo", sans-serif; }
-.reem-kufi         { font-family: "Reem Kufi", sans-serif; }
-.reem-kufi-fun     { font-family: "Reem Kufi Fun", sans-serif; }
-.reem-kufi-ink     { font-family: "Reem Kufi Ink", sans-serif; }
-.aref-ruqaa-ink    { font-family: "Aref Ruqaa Ink", serif; }
-.cairo-play        { font-family: "Cairo Play", sans-serif; }
-.ibm-plex-arabic   { font-family: "IBM Plex Sans Arabic", sans-serif; }
-.rubik             { font-family: "Rubik", sans-serif; }
+.amiri             { font-family: "Amiri", serif; }
 .amiri-quran       { font-family: "Amiri Quran", serif; }
+.kufam             { font-family: "Kufam", sans-serif; }
 
 /* ── Arabic typography system ─────────────────── */
 /* Kufam for all headings in RTL (Arabic) pages */
@@ -177,9 +169,9 @@
   font-weight: 700;
 }
 
-/* Scheherazade New for Arabic article body text */
+/* Amiri for Arabic article body text */
 .rtl-grid article p {
-  font-family: "Scheherazade New", serif;
+  font-family: "Amiri", serif;
   font-size: 1.4rem;
   font-weight: 400;
   line-height: 2.2;
@@ -188,6 +180,6 @@
 
 .rtl-grid article strong,
 .rtl-grid strong {
-  font-family: "Scheherazade New", serif;
+  font-family: "Amiri", serif;
   font-weight: 700;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,27 +11,17 @@ module.exports = {
     },
     keyframes: {
       'open-menu': {
-        '0%': {
-          transform: 'scaleY(0)',
-        },
-      },
-      'open-menu': {
-        '80%': {
-          transform: 'scaleY(1.2)',
-        },
-      },
-      'open-menu': {
-        '100%': {
-          transform: 'scaleY(1)',
-        },
+        '0%':   { transform: 'scaleY(0)' },
+        '80%':  { transform: 'scaleY(1.2)' },
+        '100%': { transform: 'scaleY(1)' },
       },
     },
-    anumation: {
+    animation: {
       'open-menu': 'open-menu 0.5s ease-in-out forwards',
     },
   },
   variants: {},
-  corPlugins: {
+  corePlugins: {
     aspectRatio: false,
   },
   plugins: [

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,49 +26,25 @@
   <!-- Arabic & extended web fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Amiri+Quran&family=Noto+Kufi+Arabic:wght@100..900&family=Noto+Sans+Arabic:wdth,wght@62.5..100,100..900&family=Scheherazade+New:wght@400;700&family=Kufam:ital,wght@0,400;0,600;0,700;0,800;0,900;1,400;1,600;1,700;1,800;1,900&family=Cairo:wght@200..900&family=Reem+Kufi:wght@400..700&family=Reem+Kufi+Fun:wght@400..700&family=Reem+Kufi+Ink&family=Aref+Ruqaa+Ink:wght@400;700&family=Cairo+Play:ital,opsz,wght@0,9..40,200..1000;1,9..40,200..1000&family=IBM+Plex+Sans+Arabic:wght@100;200;300;400;500;600;700&family=Rubik:ital,wght@0,300..900;1,300..900&display=swap" rel="stylesheet">
-  <style>
-    direction:rtl;
-    text-align:right;
-    article p {
-      direction:rtl;
-      text-align:right;
-    }
-  </style>
-
+  <link href="https://fonts.googleapis.com/css2?family=Amiri:ital,wght@0,400;0,700;1,400;1,700&family=Amiri+Quran&family=Kufam:wght@400;700&family=Noto+Sans+Arabic:wght@400&display=swap" rel="stylesheet">
   <script>
-    //// Persist user choice to localStorage
-    //if (localStorage.getItem('dark-mode') === 'true' || (!('dark-mode' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-    //  document.querySelector('html').classList.add('dark');
-    //} else {
-    //    document.querySelector('html').classList.remove('dark');
-    //}
+    const t = localStorage.getItem('color-theme');
+    if (t === 'dark' || (!t && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      document.documentElement.classList.add('dark');
+    }
   </script>
 </head>
 
-<body class="min-h-screen bg-slate-50 dark:bg-black dark:text-white selection:text-white selection:bg-blue-600 {{res.settings_font_family}} {{res.settings_body_style}}">
+<body class="min-h-screen bg-slate-50 dark:bg-black dark:text-white selection:text-white selection:bg-blue-600 {% if lang == 'ar' %}rtl-grid{% endif %}">
   <!-- Header -->
   {% include "partials/header.html" %}
 
   <!-- Main  part of the page -->
-  <main class="max-w-6xl mx-auto my-4 {{res.settings_font_family}} {{res.settings_body_style}}">
+  <main class="max-w-6xl mx-auto my-4 {% if lang == 'ar' %}rtl-grid{% endif %}">
     {% block main_content %} {% endblock %}
   </main>
 
   <!-- Footer -->
   {% include "partials/footer.html" %}
 </body>
-<script>
-  var themeToggleBtn = document.getElementById('theme-toggle');
-
-  themeToggleBtn.addEventListener('click', function() {
-      if (document.documentElement.classList.contains('dark')) {
-          document.documentElement.classList.remove('dark');
-          localStorage.setItem('color-theme', 'light');
-      } else {
-          document.documentElement.classList.add('dark');
-          localStorage.setItem('color-theme', 'dark');
-      }
-  });
-</script>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,16 +3,16 @@
 {% block main_content %}
 <!-- Intro Section -->
 <section class="flex flex-col-reverse justify-center sm:flex-row p-6
-        items-center gap-8 scroll-mt-40 {{res.settings_font_family}} {{res.settings_body_style}}">
-  <article class="sm:w-2/3 {{res.settings_font_family}} {{res.settings_body_style}}">
+        items-center gap-8 scroll-mt-40">
+  <article class="sm:w-2/3">
     {%if lang == "ar" %}
 
     <h1 class="max-w-md text-2xl font-bold sm:text-5xl text-slate-900
-            dark:text-slate-300 {{res.settings_font_family}} {{res.settings_body_style}}">
+            dark:text-slate-300">
         مُصْعَب أَحْمَد إِبْرَاهِيم<span
         class="text-teal-600 text-7xl m-0 p-0 leading-[0px]">.</span></h1>
 
-    <span class="max-wd-md text-xl text-slate-700 dark:text-slate-300 pt-5 leading-loose {{res.settings_font_family}} {{res.settings_body_style}}" style="display: block;">
+    <span class="max-wd-md text-xl text-slate-700 dark:text-slate-300 pt-5 leading-loose" style="display: block;">
       مهندس برمجيات ونظم، <span class="text-teal-600 dark:test-slate-600">ذاتيّ التَّعلُّم،</span> شغوف  <span class="bg-green-100 dark:text-slate-600"> بهندسة قواعد البيانات </span>،
       <span class="bg-yellow-50 dark: text-slate-600 dark:text-slate-600">الأنظمة الموزعة</span>،
       <span class="bg-pink-100 dark:text-slate-600">برمجة النظم</span>،
@@ -22,7 +22,7 @@
 
 
 
-    <span class="max-w-md text-xl text-slate-700 dark:text-slate-300 pt-5 leading-normal {{res.settings_font_family}} {{res.settings_body_style}}" style="display: block;">
+    <span class="max-w-md text-xl text-slate-700 dark:text-slate-300 pt-5 leading-normal" style="display: block;">
     أحب قضاء وقع فراغي مع أسرتي أو في ممارسة إحدى هواياتي التي تتضمن:
     <a href="{{get_url(path='/ar/hobbies/reading')}}" class="underline text-violet-500 hover:bg-violet-500 hover:text-white p-1 dark:text-violet-300">القراءة</a>،
     <a href="{{get_url(path='/ar/hobbies/cycling')}}"
@@ -35,15 +35,15 @@
             class="underline text-orange-600 p-1 hover:bg-orange-600 hover:text-white dark:text-orange-300">النجارة</a>.
     </span> 
 
-    <span class="max-wd-md text-xl text-slate-700 dark:text-slate-300 pt-5 {{res.settings_font_family}} {{res.settings_body_style}}" style="display: block;">
+    <span class="max-wd-md text-xl text-slate-700 dark:text-slate-300 pt-5" style="display: block;">
       يكنكم مطالعة <a href="/ar/resume" class="underline bg-teal-100 text-teal-600 dark:test-slate-600">سيرتي الذاتية</a>، أو تصفح بعض <a href="/ar/projects" class="text-yellow-600 bg-yellow-100 hover:bg-yellow-600 hover:text-white dark:text-slate-600">مشاريعي </a>.
     </span>
 
     {%else %}
     <h1 class="max-w-md text-2xl font-bold sm:text-5xl text-slate-900
-            dark:text-slate-300 {{res.settings_font_family}} {{res.settings_body_style}}">Hi, I am Mosab<span
+            dark:text-slate-300">Hi, I am Mosab<span
         class="text-teal-600 text-7xl m-0 p-0 leading-[0px]">.</span></h1>
-    <span class="max-wd-md text-xl text-slate-700 dark:text-slate-300 pt-5 {{res.settings_font_family}} {{res.settings_body_style}}" style="display: block;">
+    <span class="max-wd-md text-xl text-slate-700 dark:text-slate-300 pt-5" style="display: block;">
       A <span class="text-teal-600 dark:test-slate-600">self-taught</span> software/systems
       engineer passionate about <span class="bg-green-100 dark:text-slate-600">database
         engineering</span>,
@@ -56,7 +56,7 @@
     </span>
 
 
-    <span class="max-w-md text-xl text-slate-700 dark:text-slate-300 pt-5 {{res.settings_font_family}} {{res.settings_body_style}}" style="display: block;">
+    <span class="max-w-md text-xl text-slate-700 dark:text-slate-300 pt-5" style="display: block;">
       When not working, I like spending time with my family or indulging in one of my hobbies including <a
                                                                                         href="{{get_url(path='/hobbies/reading')}}"
         class="underline text-violet-500 hover:bg-violet-500 hover:text-white p-1 dark:text-violet-300">reading</a>, <a
@@ -70,7 +70,7 @@
         class="underline text-orange-600 p-1 hover:bg-orange-600 hover:text-white dark:text-orange-300">woodworking</a>.
     </span>
 
-    <span class="max-wd-md text-xl text-slate-700 dark:text-slate-300 pt-5 {{res.settings_font_family}} {{res.settings_body_style}}" style="display: block;">
+    <span class="max-wd-md text-xl text-slate-700 dark:text-slate-300 pt-5" style="display: block;">
       Check out <a href="/resume" class="underline bg-teal-100 text-teal-600 dark:test-slate-600">my resume</a>, or go through some of <a href="/projects" class="text-yellow-600 bg-yellow-100 hover:bg-yellow-600 hover:text-white dark:text-slate-600">my projects</a>.
     </span>
     {%endif%}

--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -1,199 +1,136 @@
 {% macro list_posts(pages) %}
-{% set res = load_data(path=config.extra.path_language_resources ~ lang ~ '.toml') %}
-<ul class="list-none mx-auto mt-8 {{res.settings_font_family}} {{res.settings_body_style}}">
+<ul class="list-none mx-auto mt-8">
   {% for page in pages %}
-      <section class="list-item">
-        <div class="post-header">
-          <li class="my-1 flex">
-            {% if page.date %}
-              <time class="text-slate-400 hidden sm:block pt-3">{{ page.date | date(format="%Y-%m-%d")
-                }}</time>
+    <section class="list-item">
+      <div class="post-header">
+        <li class="my-1 flex">
+          {% if page.date %}
+            <time class="text-slate-400 hidden sm:block pt-3">{{ page.date | date(format="%Y-%m-%d") }}</time>
+          {% endif %}
+          <a href="{{ page.permalink }}"
+            class="text-2xl mx-2 hover:text-white hover:bg-teal-600 p-1">
+            <span class="sm:hidden text-teal-600">- </span>{{ page.title }}
+            {% if page.draft %}
+              <span class="draft-label">DRAFT</span>
             {% endif %}
-
-            <a 
-            href="{{ page.permalink }}" 
-            class="text-2xl mx-2 hover:text-white hover:bg-teal-600 p-1 {{res.settings_font_family}} {{res.settings_body_style}}"><span
-                class="sm:hidden text-teal-600">- </span>{{page.title}}
-
-              {% if page.draft %}
-                <span class="draft-label">DRAFT</span>
-              {% endif %}
-            </a>
-          </li>
-          <div>
-          <div class="meta {{res.settings_font_family}} {{res.settings_body_style}}">
-            <div class="description {{res.settings_font_family}} {{res.settings_body_style}}">
+          </a>
+        </li>
+        <div>
+          <div class="meta">
+            <div class="description">
               {% if page.description %}
                 {{ page.description }}
               {% elif page.summary %}
                 {{ page.summary | safe }}&hellip;
-              {% else %}
-                {% set hide_read_more = true %}
               {% endif %}
             </div>
-
           </div>
         </div>
-      </section>
+      </div>
+    </section>
   {% endfor %}
 </ul>
-
-<!-- </article> -->
-<!-- </section> -->
 {% endmacro list_posts %}
 
 {% macro list_taxonomy_terms(terms) %}
-{% set res = load_data(path=config.extra.path_language_resources ~ lang ~ '.toml') %}
-  <ul class="list-none mx-auto mt-8 {{res.settings_font_family}} {{res.settings_body_style}}">
-      {%- for term in terms %}
-        <section class="list-item">
-          <div class="post-header">
-            <li class="my-1 flex">
-                <h1 class="title">
-                  <a href={{ term.permalink }}>{{term.name}}</a>
-                </h1>
-            </li>
-          </section>
-        </div>
-      {% endfor -%}
-  </ul>
-{% endmacro list_terms %}
+<ul class="list-none mx-auto mt-8">
+  {%- for term in terms %}
+    <section class="list-item">
+      <div class="post-header">
+        <li class="my-1 flex">
+          <h1 class="title">
+            <a href={{ term.permalink }}>{{ term.name }}</a>
+          </h1>
+        </li>
+      </div>
+    </section>
+  {% endfor -%}
+</ul>
+{% endmacro list_taxonomy_terms %}
 
 {% macro tags(page, short=false) %}
-{% set res = load_data(path=config.extra.path_language_resources ~ lang ~ '.toml') %}
-  {%- if page.taxonomies and page.taxonomies.tags %}
-    <span class="post-tags-inline {{res.settings_font_family}} {{res.settings_body_style}}">
-      {%- if short %}
-        ::
-        {%- set sep = "," -%}
-      {% else %}
-        :: tags:&nbsp;
-        {%- set sep = "&nbsp;" -%}
-      {% endif -%}
-      {%- for tag in page.taxonomies.tags %}
-        <a class="post-tag" href="{{ get_taxonomy_url(kind='tag', name=tag) | safe }}">#{{ tag }}</a>
-        {%- if not loop.last %}{{ sep | safe }}{% endif -%}
-      {% endfor -%}
-    </span>
-  {% endif -%}
+{%- if page.taxonomies and page.taxonomies.tags %}
+  <span class="post-tags-inline">
+    {%- if short %}
+      ::
+      {%- set sep = "," -%}
+    {% else %}
+      :: tags:&nbsp;
+      {%- set sep = "&nbsp;" -%}
+    {% endif -%}
+    {%- for tag in page.taxonomies.tags %}
+      <a class="post-tag" href="{{ get_taxonomy_url(kind='tag', name=tag) | safe }}">#{{ tag }}</a>
+      {%- if not loop.last %}{{ sep | safe }}{% endif -%}
+    {% endfor -%}
+  </span>
+{% endif -%}
 {% endmacro tags %}
 
 {% macro page_header(title) %}
-{% set res = load_data(path=config.extra.path_language_resources ~ lang ~ '.toml') %}
-  <h1 class="text-3xl font-bold sm:text-4xl text-slate-900 dark:text-slate-300 {{res.settings_font_family}} {{res.settings_body_style}}">
-    {{title}}<span class="text-teal-600 text-7xl m-0 p-0 leading-[0px]">.</span></h2>
+<h1 class="text-3xl font-bold sm:text-4xl text-slate-900 dark:text-slate-300">
+  {{ title }}<span class="text-teal-600 text-7xl m-0 p-0 leading-[0px]">.</span>
+</h1>
 {% endmacro page_header %}
 
 {% macro content(page) %}
 {% set res = load_data(path=config.extra.path_language_resources ~ lang ~ '.toml') %}
-<!-- Intro Section -->
-<section class="flex flex-col justify-center sm:flex-row p-6 items-center gap-8  {{res.settings_font_family}} {{res.settings_body_style}}">
-  <article class="w-screen px-4 sm:px-0 {{res.settings_font_family}} {{res.settings_body_style}}">
+<section class="flex flex-col justify-center sm:flex-row p-6 items-center gap-8">
+  <article class="w-screen px-4 sm:px-0">
     {{ post_macros::page_header(title=page.title) }}
 
     {% if page.date %}
-      <span 
-        class="text-slate-400 sm:text-1/2xl text-sl font-mono {{res.settings_font_family}} {{res.settings_body_style}}">{{res.posted_on}} <time 
-          class="text-slate-500">{{ page.date |
-          date(format="%Y-%m-%d") }}</time></span>
+      <span class="text-slate-400 sm:text-1/2xl text-sl font-mono">
+        {{ res.posted_on }}
+        <time class="text-slate-500">{{ page.date | date(format="%Y-%m-%d") }}</time>
+      </span>
     {% endif %}
 
     {% if page.draft %}
       <span class="draft-label">DRAFT</span>
     {% endif %}
 
-    {# Optional table of contents #}
     {% if page.extra.toc | default(value=false) %}
       {% if page.toc %}
-      <h1>{{res.table_of_contents}}</h1>
-      <ul>
-        {% for h1 in page.toc %}
-        <li>
-          <a href="{{ h1.permalink | safe }}">{{ h1.title }}</a>
-          {% if h1.children %}
-          <ul>
-            {% for h2 in h1.children %}
-            <li>
-              <a href="{{ h2.permalink | safe }}">{{ h2.title }}</a>
-            </li>
-
-            {% if h2.children %}
+        <h1>{{ res.table_of_contents }}</h1>
+        <ul>
+          {% for h1 in page.toc %}
+          <li>
+            <a href="{{ h1.permalink | safe }}">{{ h1.title }}</a>
+            {% if h1.children %}
             <ul>
-              {% for h3 in h2.children %}
+              {% for h2 in h1.children %}
               <li>
-                <a href="{{ h3.permalink | safe }}">{{ h3.title }}</a>
+                <a href="{{ h2.permalink | safe }}">{{ h2.title }}</a>
               </li>
+              {% if h2.children %}
+              <ul>
+                {% for h3 in h2.children %}
+                <li><a href="{{ h3.permalink | safe }}">{{ h3.title }}</a></li>
+                {% endfor %}
+              </ul>
+              {% endif %}
               {% endfor %}
             </ul>
             {% endif %}
-            {% endfor %}
-          </ul>
-          {% endif %}
-        </li>
-        {% endfor %}
-      </ul>
+          </li>
+          {% endfor %}
+        </ul>
       {% endif %}
     {% endif %}
 
-    <div class="my-4 {{res.settings_font_family}} {{res.settings_body_style}}">
+    <div class="my-4">
       {{ page.content | safe }}
 
       {% if page.taxonomies and page.taxonomies.tags %}
-        <aside class="text-sl text-slate-700 dark:text-slate-300 mt-8
-              font-mono {{res.settings_font_family}} {{res.settings_body_style}}">
+        <aside class="text-sl text-slate-700 dark:text-slate-300 mt-8 font-mono">
           Tags:
           {% for tag in page.taxonomies.tags %}
-            <a href="{{ get_taxonomy_url(kind='tags' , name=tag) | safe }}"
+            <a href="{{ get_taxonomy_url(kind='tags', name=tag) | safe }}"
               class="text-teal-600 p-1 hover:text-white hover:bg-teal-600">#{{ tag }}</a>
           {% endfor %}
         </aside>
       {% endif %}
-
     </div>
   </article>
 </section>
 {% endmacro content %}
-
-
-{% macro cards_posts(pages) %}
-{% set res = load_data(path=config.extra.path_language_resources ~ lang ~ '.toml') %}
-<div class="cards">
-  {%- for page in pages %}
-    <div class="card">
-      {% if page.extra.local_image %}
-        <img class="card-image" alt={{ page.extra.local_image }} src="{{ get_url(path=page.extra.local_image) }}" />
-      {% elif page.extra.remote_image %}
-        <img class="card-image" alt={{ page.extra.remote_image }} src="{{ page.extra.remote_image }}" />
-      {% else %}
-        <div class="card-image-placeholder"></div>
-      {% endif %}
-
-      <div class="card-info">
-        <h1 class="card-title">
-          {% if page.extra.link_to %}
-            <a href={{ page.extra.link_to }}>{{page.title}}</a>
-          {% else %}
-            <a href={{ page.permalink }}>{{page.title}}</a>
-          {% endif %}
-        </h1>
-
-        <div class="meta">
-          {%- if page.date %}
-            <time>{{ page.date | date(format="%Y-%m-%d") }}</time>
-          {% endif -%}
-
-          {% if page.draft %}
-            <span class="draft-label">DRAFT</span>
-          {% endif %}
-        </div>
-
-        <div class="card-description">
-          {% if page.description %}
-            {{ page.description }}
-          {% endif %}
-        </div>
-      </div>
-    </div>
-  {% endfor -%}
-</div>
-{% endmacro cards_posts %}

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -11,7 +11,8 @@
 <header class="text-black dark:text-slate-200 top-0 z-10">
   <section class="max-w-6xl mx-auto p-4 flex justify-between items-center">
     <div>
-      <button id="hamburger-button" class="text-3xl sm:hidden cursor-pointer">
+      <button id="hamburger-button" class="text-3xl sm:hidden cursor-pointer"
+        aria-expanded="false" aria-controls="mobile-menu" aria-label="Open menu">
         &#9776;
       </button>
 
@@ -32,15 +33,15 @@
         </a>
 
         <!-- Dark/Light theme toggle -->
-        <!-- <button class="cursor-pointer" id="theme-toggle"> -->
-        <!--   <i class="mdi mdi-brightness-6" /> -->
-        <!-- </button> -->
+        <button class="cursor-pointer" id="theme-toggle" aria-label="Toggle dark mode">
+          <i class="mdi mdi-brightness-6"></i>
+        </button>
       </nav>
     </div>
   </section>
   <section id="mobile-menu"
     class="absolute top-0 z-10 bg-slate-200 dark:bg-black w-full text-teal-600 dark:text-white text-3xl flex-col justify-content-center origin-top animate-open-menu hidden">
-    <button class="text-6xl cursor-pointer self-end px-6">
+    <button class="text-6xl cursor-pointer self-end px-6" aria-label="Close menu">
       &times;
     </button>
     <nav class="flex flex-col min-h-screen items-center py-8" aria-label="mobile">

--- a/templates/section.html
+++ b/templates/section.html
@@ -2,8 +2,8 @@
 
 {% block main_content %}
   <!-- Intro Section -->
-  <section class="flex flex-col-reverse justify-center sm:flex-row p-6 items-center gap-8 {{res.settings_font_family}} {{res.settings_body_style}}">
-    <article class="w-screen px-4 sm:px-0 {{res.settings_font_family}} {{res.settings_body_style}}">
+  <section class="flex flex-col-reverse justify-center sm:flex-row p-6 items-center gap-8">
+    <article class="w-screen px-4 sm:px-0">
       {% if section.extra.section_path %}
         {% set section = get_section(path=section.extra.section_path) %}
       {% endif %}
@@ -23,7 +23,7 @@
       {% endblock post_list %}
 
       {% if paginator %}
-        <ul class="pagination text-center mt-8 {{res.settings_font_family}} {{res.settings_body_style}}">
+        <ul class="pagination text-center mt-8">
           {% if paginator.previous %}
           <span class="page-item page-prev">
             <a href={{ paginator.previous }} class="page-link" aria-label="Previous"><span aria-hidden="true">{{res.previous_posts}}</span></a>

--- a/templates/shortcodes/quote.html
+++ b/templates/shortcodes/quote.html
@@ -6,7 +6,7 @@
       aria-hidden="true">{% if lang == 'ar' %}«{% else %}"{% endif %}</span>
     <p class="not-italic leading-loose text-slate-700 dark:text-slate-200 font-medium
              text-{% if size %}{{ size }}{% else %}2xl{% endif %}
-             {% if font %}{{ font }}{% elif lang == 'ar' %}scheherazade-new{% endif %}">
+             {% if font %}{{ font }}{% endif %}">
       {{ text | safe }}
     </p>
   </blockquote>

--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -2,8 +2,8 @@
 
 {% block main_content %}
   <!-- Intro Section -->
-  <section class="flex flex-col-reverse justify-center sm:flex-row p-6 items-center gap-8 {{res.settings_font_family}} {{res.settings_body_style}}">
-    <article class="w-screen px-4 sm:px-0 {{res.settings_font_family}} {{res.settings_body_style}}">
+  <section class="flex flex-col-reverse justify-center sm:flex-row p-6 items-center gap-8">
+    <article class="w-screen px-4 sm:px-0">
       {% block title %}
         {{ post_macros::page_header(title=taxonomy.name) }}
       {% endblock title %}

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -2,8 +2,8 @@
 
 {% block main_content %}
   <!-- Intro Section -->
-  <section class="flex flex-col-reverse justify-center sm:flex-row p-6 items-center gap-8 {{res.settings_font_family}} {{res.settings_body_style}}">
-    <article class="w-screen px-4 sm:px-0 {{res.settings_font_family}} {{res.settings_body_style}}">
+  <section class="flex flex-col-reverse justify-center sm:flex-row p-6 items-center gap-8">
+    <article class="w-screen px-4 sm:px-0">
       {% block title %}
           {{ post_macros::page_header(title=term.name | capitalize) }}
       {% endblock title %}


### PR DESCRIPTION
## Summary

- Fix broken inline `<style>` block in `base.html` (bare declarations with no selector)
- Fix two typos in tailwind.config.js: `anumation` → `animation`, `corPlugins` → `corePlugins`; also merge split keyframe definitions into one object
- Fix package.json production build output filename (`styles.css` → `style.css`)
- Remove `font-medium` from `article p` base layer (was forcing weight 500 on body text)
- Trim Google Fonts from 14 families down to 4 (Amiri, Amiri Quran, Kufam, Noto Sans Arabic)
- Remove unused Arabic font utility classes; add Amiri as the default `.rtl-grid` font via CSS
- Add ARIA attributes to mobile menu (`aria-expanded`, `aria-controls`, `aria-label`)
- Restore dark mode toggle: uncomment button, move theme script into `main.js`, add `localStorage` init to `<head>` to prevent flash of wrong theme, fix dangling `<script>` after `</body>`
- Enable minify_html and lazy_async_image in config.toml
- Remove dead `cards_posts` macro
- Simplify quote.html: drop hardcoded Arabic font default, let CSS inheritance handle it
- Eliminate `settings_font_family` and `settings_body_style` from i18n files; hardcode RTL layout class in templates using lang variable

## Test Plan

- [x] `zola build` passes with no errors